### PR TITLE
Code refactoring and added a Try-Catch block for preventing the model from being saved with test assessments still commented if the execution fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore the sorting file for MacOS
 *.DS_Store
+staliro
+Models/AT/sldemo_autotrans_data.mat

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ To run this tool, it is necessary to download S-Taliro from the following link: 
 
 In addition, the following Matlab script must be removed from the S-Taliro folder: `./auxiliary/Compute_Robustness.m`
 
+Moreover, in the S-Taliro folder, the file `./demos/RTTs for Testing ADS/src/modifications_to_staliro/optimization/SA_Taliro.m` must be edited by adding before the first call to the Compute_Rombustness function, the following lines
+```
+addpath('TranslationFunctions/Function_STaliro')
+rmpath('TranslationFunctions/Function_Hecate')
+```
+
 The folder containing S-Taliro should then be placed in the main folder (at the same level as `TranslationFunctions`) and be renamed `staliro`.
 
 ## How to Run

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ In addition, the following Matlab script must be removed from the S-Taliro folde
 
 Moreover, in the S-Taliro folder, the file `./demos/RTTs for Testing ADS/src/modifications_to_staliro/optimization/SA_Taliro.m` must be edited by adding before the first call to the Compute_Rombustness function, the following lines
 ```
-addpath('TranslationFunctions/Function_STaliro')
-rmpath('TranslationFunctions/Function_Hecate')
+rmpath('TranslationFunctions/Function_STaliro')
+addpath('TranslationFunctions/Function_Hecate')
 ```
 
 The folder containing S-Taliro should then be placed in the main folder (at the same level as `TranslationFunctions`) and be renamed `staliro`.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ To run this tool, it is necessary to download S-Taliro from the following link: 
 
 In addition, the following Matlab script must be removed from the S-Taliro folder: `./auxiliary/Compute_Robustness.m`
 
-Moreover, in the S-Taliro folder, the file `./demos/RTTs for Testing ADS/src/modifications_to_staliro/optimization/SA_Taliro.m` must be edited by adding before the first call to the Compute_Rombustness function, the following lines
-```
-rmpath('TranslationFunctions/Function_STaliro')
-addpath('TranslationFunctions/Function_Hecate')
-```
-
 The folder containing S-Taliro should then be placed in the main folder (at the same level as `TranslationFunctions`) and be renamed `staliro`.
 
 ## How to Run

--- a/getFileName.m
+++ b/getFileName.m
@@ -1,7 +1,8 @@
-function [fileName] = getFileName(tool)
+function [fileName] = getFileName(tool, settingName)
 %GETFILENAME Returns the fileName for test results, depending on the tool
 %   Inputs:
 %       tool: the name of the tool
+%       settingName: the name of the file containing the execution settings
 %
 %   Outputs:
 %       fileName: char array containing file name

--- a/getFileName.m
+++ b/getFileName.m
@@ -1,0 +1,17 @@
+function [fileName] = getFileName(tool)
+%GETFILENAME Returns the fileName for test results, depending on the tool
+%   Inputs:
+%       tool: the name of the tool
+%
+%   Outputs:
+%       fileName: char array containing file name
+
+fileName = datestr(now,'dd_mm_yy_HHMM');
+    if contains(settingName,'setting','IgnoreCase',true)
+        nameStr = erase(settingName,{'Setting','setting'});
+        fileName = strcat('./TestResults/', tool, '_', nameStr,'_',fileName,'.mat');
+    else
+        fileName = strcat('./TestResults/', tool, '_', model,'_',fileName,'.mat');
+    end
+end
+

--- a/getFileName.m
+++ b/getFileName.m
@@ -7,7 +7,12 @@ function [fileName] = getFileName(tool, settingName)
 %   Outputs:
 %       fileName: char array containing file name
 
-fileName = datestr(now,'dd_mm_yy_HHMM');
+    % Create name of save file
+    if ~isfolder('TestResults')
+        mkdir('TestResults')
+    end
+
+    fileName = datestr(now,'dd_mm_yy_HHMM');
     if contains(settingName,'setting','IgnoreCase',true)
         nameStr = erase(settingName,{'Setting','setting'});
         fileName = strcat('./TestResults/', tool, '_', nameStr,'_',fileName,'.mat');

--- a/runHecate.m
+++ b/runHecate.m
@@ -93,13 +93,7 @@ function runHecate(settingName,n_runs)
         mkdir('TestResults')
     end
     
-    fileStr = datestr(now,'dd_mm_yy_HHMM');
-    if contains(settingName,'setting','IgnoreCase',true)
-        nameStr = erase(settingName,{'Setting','setting'});
-        fileStr = strcat('./TestResults/', tool, '_', nameStr,'_',fileStr,'.mat');
-    else
-        fileStr = strcat('./TestResults/', tool, '_', model,'_',fileStr,'.mat');
-    end
+    fileStr = getFileName(tool)
 
     % Check that the correct version of 'Compute_Robustness' is active
     addpath('TranslationFunctions/Function_Hecate')

--- a/runHecate.m
+++ b/runHecate.m
@@ -93,7 +93,7 @@ function runHecate(settingName,n_runs)
         mkdir('TestResults')
     end
     
-    fileStr = getFileName(tool)
+    fileStr = getFileName(tool, settingName)
 
     % Check that the correct version of 'Compute_Robustness' is active
     addpath('TranslationFunctions/Function_Hecate')

--- a/runHecate.m
+++ b/runHecate.m
@@ -35,7 +35,7 @@ function runHecate(settingName,n_runs)
     else
         error('There is no Setting file in the current workpath with the given name.')
     end
-
+    
     % Set the name of the model
     if isa(model,'char')
         modelname = model;
@@ -45,7 +45,7 @@ function runHecate(settingName,n_runs)
         [test_assessment_path,test_sequence_path] = simConfig(modelname,activeScenarioTA,activeScenarioTS,input_param,model);
     else
         error('Model type is not supported.')
-    end
+    end    
 
     %% Set up translation map
 
@@ -96,9 +96,9 @@ function runHecate(settingName,n_runs)
     fileStr = datestr(now,'dd_mm_yy_HHMM');
     if contains(settingName,'setting','IgnoreCase',true)
         nameStr = erase(settingName,{'Setting','setting'});
-        fileStr = strcat('./TestResults/Hecate_',nameStr,'_',fileStr,'.mat');
+        fileStr = strcat('./TestResults/', tool, '_', nameStr,'_',fileStr,'.mat');
     else
-        fileStr = strcat('./TestResults/Hecate_',model,'_',fileStr,'.mat');
+        fileStr = strcat('./TestResults/', tool, '_', model,'_',fileStr,'.mat');
     end
 
     % Check that the correct version of 'Compute_Robustness' is active

--- a/runHecate.m
+++ b/runHecate.m
@@ -65,7 +65,7 @@ function runHecate(settingName,n_runs)
     transTableTS = getAllTrans(stepTableTS,test_sequence_path);
     
     % Create the state Transition Map
-    [stepTableTA, transTableTA, junctionTableTA] = buildTransitionMap(test_assessment_path, stepTableTA, transTableTA, fitTable);
+    [~, ~, ~] = buildTransitionMap(test_assessment_path, stepTableTA, transTableTA, fitTable);
 
     % Check the given input parameters
     input_search = checkTestSequenceParameter(test_sequence_path,input_param,stepTableTS,transTableTS);

--- a/runHecate.m
+++ b/runHecate.m
@@ -87,12 +87,6 @@ function runHecate(settingName,n_runs)
     %% Run Hecate
 
     tool = 'Hecate';
-
-    % Create name of save file
-    if ~isfolder('TestResults')
-        mkdir('TestResults')
-    end
-    
     fileStr = getFileName(tool, settingName)
 
     % Check that the correct version of 'Compute_Robustness' is active

--- a/runSTaliro.m
+++ b/runSTaliro.m
@@ -48,12 +48,6 @@ function runSTaliro(settingName,n_runs)
     %% Run S-Taliro
 
     tool = 'S-Taliro';
-
-    % Create name of save file
-    if ~isfolder('TestResults')
-        mkdir('TestResults')
-    end
-
     fileStr = getFileName(tool, settingName)
     
     % Check that the correct version of 'Compute_Robustness' is active

--- a/runSTaliro.m
+++ b/runSTaliro.m
@@ -85,17 +85,29 @@ function runSTaliro(settingName,n_runs)
     History = [];
     Options = [];
     
-    % Run S-Taliro
-    for ii = 1:n_runs
-        fprintf('\n\t\t*\t*\t*\n\nRun: %i/%i\n\n',ii,n_runs)
-        [results, history, opt] = staliro(modelname, init_cond, staliro_InputBounds, staliro_cp_array, phi, preds, simulationTime, staliro_opt);
-        Results = [Results; results];
-        History = [History; history];
-        Options = [Options; opt];
-
-        assignin('base','ResultsSTaliro',Results)
-        assignin('base','HistorySTaliro',History)
-%         save(fileStr);
+    % Execute S-Taliro in a Try-Catch block so that if execution fails, the
+    % commented part (i.e., test assesments) are then uncommented
+    try
+        % Run S-Taliro
+        for ii = 1:n_runs
+            fprintf('\n\t\t*\t*\t*\n\nRun: %i/%i\n\n',ii,n_runs)
+            [results, history, opt] = staliro(modelname, init_cond, staliro_InputBounds, staliro_cp_array, phi, preds, simulationTime, staliro_opt);
+            Results = [Results; results];
+            History = [History; history];
+            Options = [Options; opt];
+    
+            assignin('base','ResultsSTaliro',Results)
+            assignin('base','HistorySTaliro',History)
+    %         save(fileStr);
+        end
+    catch ME
+        % Uncomment the Test Assessment block
+        set_param(test_assessment_path,'Commented','off');
+        % Close Simulink model
+        save_system(modelname)
+        causeException = MException('MATLAB:Hecate:STaliroError',msg);
+        ME = addCause(ME,causeException);
+        rethrow(ME)
     end
     
     %% Close the model and save the results

--- a/runSTaliro.m
+++ b/runSTaliro.m
@@ -54,13 +54,7 @@ function runSTaliro(settingName,n_runs)
         mkdir('TestResults')
     end
 
-    fileStr = datestr(now,'dd_mm_yy_HHMM');
-    if contains(settingName,'setting','IgnoreCase',true)
-        nameStr = erase(settingName,{'Setting','setting'});
-        fileStr = strcat('./TestResults/STaliro_',nameStr,'_',fileStr,'.mat');
-    else
-        fileStr = strcat('./TestResults/STaliro_',model,'_',fileStr,'.mat');
-    end
+    fileStr = getFileName(tool)
     
     % Check that the correct version of 'Compute_Robustness' is active
     addpath('TranslationFunctions/Function_STaliro')

--- a/runSTaliro.m
+++ b/runSTaliro.m
@@ -54,7 +54,7 @@ function runSTaliro(settingName,n_runs)
         mkdir('TestResults')
     end
 
-    fileStr = getFileName(tool)
+    fileStr = getFileName(tool, settingName)
     
     % Check that the correct version of 'Compute_Robustness' is active
     addpath('TranslationFunctions/Function_STaliro')


### PR DESCRIPTION
- Updated gitignore. Now staliro folder is automatically ignored
- Some refactoring: a single function to get the fileName depending on the tool is used without code duplication
- runStaliro and runHecate now execute the tool in a try catch block, preventing the simulink model being saved with test assessments still commented if the execution of the tools fails